### PR TITLE
Add dev-dependency on `cstr_core` with the `alloc` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ cstr_core = { version = "0.2.2", default-features = false }
 bitflags = "1.2.1"
 itertools = { version = "0.9.0", default-features = false }
 
+[dev-dependencies]
+cstr_core = { version = "0.2.2", features = ["alloc"] }
+
 [features]
 default = ["std"]
 std = []


### PR DESCRIPTION
This is a fixup for https://github.com/lights0123/printf-compat/pull/1 to make `cargo test` work.