### PR TITLE
Update CI so that it runs on pushes and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   pull_request:
+    branches:
+      - master
   push:
+    branches:
+      - master
   schedule:
     - cron: '0 1 * * *'
 


### PR DESCRIPTION
I think currently the CI isn't running for PRs or pushes to `master`, I think this change should fix that. 