### PR TITLE
Switch to `core::ffi` types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-cty = "0.2.1"
-cstr_core = { version = "0.2.2", default-features = false }
 bitflags = "1.2.1"
 itertools = { version = "0.9.0", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Start by adding the unstable feature:
 Now, add your function signature:
 
 ```rust
-use cty::{c_char, c_int};
+use core::ffi::{c_char, c_int};
 
 #[no_mangle]
 unsafe extern "C" fn c_library_print(str: *const c_char, mut args: ...) -> c_int {
@@ -76,8 +76,7 @@ unsafe extern "C" fn c_library_print(str: *const c_char, mut args: ...) -> c_int
 }
 ```
 
-If you have access to [`std`], i.e. not an embedded platform, you can use
-[`std::os::raw`] instead of [`cty`]. Also, think about what you're doing:
+Think about what you're doing:
 
 - If you're implenting `printf` *because you don't have one*, you'll want to
   call it `printf` and add `#[no_mangle]`.
@@ -118,7 +117,6 @@ License: MIT OR Apache-2.0
 [std::io::stdout]: https://doc.rust-lang.org/std/io/fn.stdout.html
 [`std`]: https://doc.rust-lang.org/std/index.html
 [`std::os::raw`]: https://doc.rust-lang.org/stable/std/os/raw/index.html
-[`cty`]: https://docs.rs/cty/0.2/cty/
 [output::fmt_write]: https://docs.rs/printf-compat/0.1/printf_compat/output/fn.fmt_write.html
 [`output::fmt_write`]: https://docs.rs/printf-compat/0.1/printf_compat/output/fn.fmt_write.html
 [output::fmt_write#differences]: https://docs.rs/printf-compat/0.1/printf_compat/output/fn.fmt_write.html#differences

--- a/README.tpl
+++ b/README.tpl
@@ -12,7 +12,6 @@ License: {{license}}
 [std::io::stdout]: https://doc.rust-lang.org/std/io/fn.stdout.html
 [`std`]: https://doc.rust-lang.org/std/index.html
 [`std::os::raw`]: https://doc.rust-lang.org/stable/std/os/raw/index.html
-[`cty`]: https://docs.rs/cty/0.2/cty/
 [output::fmt_write]: https://docs.rs/printf-compat/0.1/printf_compat/output/fn.fmt_write.html
 [`output::fmt_write`]: https://docs.rs/printf-compat/0.1/printf_compat/output/fn.fmt_write.html
 [output::fmt_write#differences]: https://docs.rs/printf-compat/0.1/printf_compat/output/fn.fmt_write.html#differences

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! ```rust
 //! # #![feature(c_variadic)]
-//! use cty::{c_char, c_int};
+//! use core::ffi::{c_char, c_int};
 //!
 //! #[no_mangle]
 //! unsafe extern "C" fn c_library_print(str: *const c_char, mut args: ...) -> c_int {
@@ -72,8 +72,7 @@
 //! }
 //! ```
 //!
-//! If you have access to [`std`], i.e. not an embedded platform, you can use
-//! [`std::os::raw`] instead of [`cty`]. Also, think about what you're doing:
+//! Think about what you're doing:
 //!
 //! - If you're implenting `printf` *because you don't have one*, you'll want to
 //!   call it `printf` and add `#[no_mangle]`.
@@ -88,7 +87,7 @@
 //!
 //! ```rust
 //! # #![feature(c_variadic)]
-//! # use cty::{c_char, c_int};
+//! # use core::ffi::{c_char, c_int};
 //! # #[no_mangle]
 //! # unsafe extern "C" fn c_library_print(str: *const c_char, mut args: ...) -> c_int {
 //! use printf_compat::{format, output};
@@ -115,9 +114,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(c_variadic)]
 
-use core::fmt;
-use cstr_core::CStr;
-use cty::*;
+extern crate alloc;
+
+use core::{fmt, ffi::*};
 
 pub mod output;
 mod parser;

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,11 +1,9 @@
 //! Various ways to output formatting data.
 
 use core::cell::Cell;
-use core::ffi::VaList;
+use core::ffi::*;
 use core::fmt;
 use core::str::from_utf8;
-
-use cty::*;
 
 #[cfg(feature = "std")]
 pub use yes_std::*;
@@ -326,7 +324,7 @@ pub unsafe fn display<'a, 'b>(
 /// ```rust
 /// #![feature(c_variadic)]
 ///
-/// use cty::{c_char, c_int};
+/// use core::ffi::{c_char, c_int};
 ///
 /// #[no_mangle]
 /// unsafe extern "C" fn c_library_print(str: *const c_char, mut args: ...) -> c_int {
@@ -335,9 +333,6 @@ pub unsafe fn display<'a, 'b>(
 ///     format.bytes_written()
 /// }
 /// ```
-///
-/// If you have access to [`std`], i.e. not an embedded platform, you can use
-/// [`std::os::raw`] instead of [`cty`].
 pub struct VaListDisplay<'a, 'b> {
     format: *const c_char,
     va_list: VaList<'a, 'b>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,4 @@
-use core::ffi::VaList;
-
-use cstr_core::CStr;
-use cty::*;
+use core::ffi::*;
 
 use crate::{Argument, DoubleFormat, Flags, SignedInt, Specifier, UnsignedInt};
 use itertools::Itertools;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,4 @@
-use core::ptr::null_mut;
-use cty::*;
+use core::{ffi::*, ptr::null_mut};
 
 extern "C" {
     fn asprintf(s: *mut *mut u8, format: *const u8, ...) -> c_int;
@@ -32,9 +31,9 @@ macro_rules! c_fmt {
         let mut ptr = null_mut();
         let bytes_written = asprintf(&mut ptr, $format $(, $p)*);
         assert!(bytes_written >= 0);
-        let str: String = cstr_core::CStr::from_ptr(ptr as *const _).to_string_lossy().into();
+        let s: String = CStr::from_ptr(ptr as *const _).to_string_lossy().into();
         free(ptr as _);
-        (bytes_written, str)
+        (bytes_written, s)
     }};
 }
 


### PR DESCRIPTION
These ~~will be~~ are now stable in 1.64, so remove the now unneeded dependencies.

---

This also closes https://github.com/lights0123/printf-compat/pull/2.