### PR TITLE
Update CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,20 +34,13 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          target: thumbv7m-none-eabi
-          default: true
-          components: rustfmt, clippy
+        run: |
+          rustup toolchain install nightly --target thumbv7m-none-eabi --component clippy,rustfmt
+          rustup default nightly
       - run: cargo install cargo-readme
       - run: cargo test
       - name: cargo build no_std
         run: cargo build --target thumbv7m-none-eabi --no-default-features
-      - name: cargo clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+      - run: cargo clippy -- -D warnings
       - name: Ensure README.md is updated
         run: '[ "$(< README.md)" = "$(cargo readme)" ]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     name: cargo +nightly build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           rustup toolchain install nightly --target thumbv7m-none-eabi --component clippy,rustfmt
           rustup default nightly
+      - run: cargo fmt -- --check
       - run: cargo install cargo-readme
       - run: cargo test
       - name: cargo build no_std

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@
 
 extern crate alloc;
 
-use core::{fmt, ffi::*};
+use core::{ffi::*, fmt};
 
 pub mod output;
 mod parser;


### PR DESCRIPTION
* Use latest checkout/cache versions.
* Stop using actions-rs: it's no longer maintained. Use direct rustup/cargo calls instead. Only loss of functionality is that warnings/lints aren't shown as inline annotations; you have to click through to the action output if it fails.
* Add a missing `cargo fmt` check.

This depends on https://github.com/lights0123/printf-compat/pull/5 to fix the clippy lints.