### PR TITLE
unconditional dependency on alloc is a problem in no_std/no_alloc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - run: cargo test
       - name: cargo build no_std
         run: cargo build --target thumbv7m-none-eabi --no-default-features
+        working-directory: ensure_no_std
       - name: cargo clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
-Cargo.lock
+**/target
+**/Cargo.lock

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ensure_no_std"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+printf-compat = { path = "..", default-features = false }
+

--- a/ensure_no_std/src/main.rs
+++ b/ensure_no_std/src/main.rs
@@ -1,0 +1,10 @@
+#![no_main]
+#![no_std]
+
+use core::panic::PanicInfo;
+use printf_compat as _; // ensure it gets linked
+
+#[panic_handler]
+fn panic(_panic: &PanicInfo<'_>) -> ! {
+    loop {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,12 +111,10 @@
 //! [`ufmt`]: https://docs.rs/ufmt/
 //! [`defmt`]: https://defmt.ferrous-systems.com/
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![feature(c_variadic)]
 
-extern crate alloc;
-
-use core::{fmt, ffi::*};
+use core::{ffi::*, fmt};
 
 pub mod output;
 mod parser;


### PR DESCRIPTION
alloc is only required for tests(?) so just make no_std conditional on tests|"std" instead

The CI no_std check failed to catch this because you're not building an executable (dependencies are not being checked). Minimal executable has been added and CI now builds that

depends on https://github.com/lights0123/printf-compat/pull/5 to fix the clippy lints.