### PR TITLE
Support NULL pointers in '%s'.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -187,7 +187,16 @@ pub unsafe fn format(
                     value: args.arg(),
                     format: DoubleFormat::Hex.set_upper(ch.is_ascii_uppercase()),
                 },
-                b's' => Specifier::String(CStr::from_ptr(args.arg())),
+                b's' => {
+                    let arg: *mut c_char = args.arg();
+                    // As a common extension supported by glibc, musl, and
+                    // others, format a NULL pointer as "(null)".
+                    if arg.is_null() {
+                        Specifier::Bytes(b"(null)")
+                    } else {
+                        Specifier::String(CStr::from_ptr(arg))
+                    }
+                }
                 b'c' => Specifier::Char(args.arg()),
                 b'p' => Specifier::Pointer(args.arg()),
                 b'n' => Specifier::WriteBytesWritten(written, args.arg()),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -73,6 +73,7 @@ fn test_str() {
         assert_eq_fmt!(c_str!("%10.4s"), c_str!("world"));
         assert_eq_fmt!(c_str!("%-10.4s"), c_str!("world"));
         assert_eq_fmt!(c_str!("%-10s"), c_str!("world"));
+        assert_eq_fmt!(c_str!("%s"), null_mut::<c_char>());
     }
 }
 


### PR DESCRIPTION
glibc, musl, and other common libc implementations allow a NULL pointer to be passed to the `%s` specifier, and format it as "(null)". This patch adds support to printf-compat to do the same.