### PR TITLE
ci: Update to checkout/cache actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     name: cargo +nightly build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin


### PR DESCRIPTION
The v2 cache version has been deprecated and that prevents CI from running; update to the latest version (v4).