### PR TITLE
ci: Remove use of actions-rs/clippy-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,6 @@ jobs:
       - run: cargo test
       - name: cargo build no_std
         run: cargo build --target thumbv7m-none-eabi --no-default-features
-      - name: cargo clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+      - run: cargo clippy --all-features
       - name: Ensure README.md is updated
         run: '[ "$(< README.md)" = "$(cargo readme)" ]'


### PR DESCRIPTION
actions-rs/clippy-check has been deprecated for a while, so just run clippy directly. Note that this means lint annotations will no longer be shown, but clippy errors can still be seen in the action output.