### PR TITLE
Update bitflags to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "2.9.1"
 itertools = { version = "0.14.0", default-features = false }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@ pub mod argument {
         ///
         /// Definitions from
         /// [Wikipedia](https://en.wikipedia.org/wiki/Printf_format_string#Flags_field).
+        #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
         pub struct Flags: u8 {
             /// Left-align the output of this placeholder. (The default is to
             /// right-align the output.)


### PR DESCRIPTION
Note that bitflags v2 no longer automatically derives by default, so add a standard list of common derives.