### PR TITLE
ci: Add Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches:
+      - main
+      
+name: Release
+
+permissions:
+  # Required for pushing the release tag.
+  contents: write
+  # Required for crates.io Trusted Publishing.
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo install auto-release
+      - run: auto-release -p printf-compat --condition subject
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This uses the [auto-release] crate to create a new crates.io release and push a github tag. The [Trusted Publishing] feature is used to provide the crates.io token.

[auto-release]: https://crates.io/crates/auto-release
[Trusted Publishing]: https://blog.rust-lang.org/2025/07/11/crates-io-development-update-2025-07/