### PR TITLE
Remove version from readme/docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ pre-written adapters for [`fmt::Write`][output::fmt_write] (like a
 
 ### 🔬 Small
 
-This crate is `no_std` compatible (`printf-compat = { version = "0.1",
-default-features = false }` in your Cargo.toml). The main machinery doesn't
-require the use of [`core::fmt`], and it can't panic.
+This crate is `no_std` compatible (with `default-features = false`).
+The main machinery doesn't require the use of [`core::fmt`], and it can't panic.
 
 ### 🔒 Safe (as can be)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,8 @@
 //!
 //! ## 🔬 Small
 //!
-//! This crate is `no_std` compatible (`printf-compat = { version = "0.1",
-//! default-features = false }` in your Cargo.toml). The main machinery doesn't
-//! require the use of [`core::fmt`], and it can't panic.
+//! This crate is `no_std` compatible (with `default-features = false`).
+//! The main machinery doesn't require the use of [`core::fmt`], and it can't panic.
 //!
 //! ## 🔒 Safe (as can be)
 //!


### PR DESCRIPTION
Remove the explicit `version = "0.1"` so that we don't have to update it when releasing new versions.