### PR TITLE
workflows: Install auto-release on the stable channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
-      - run: cargo install auto-release
+      - run: cargo +stable install auto-release
       - run: auto-release -p printf-compat --condition subject
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
By default the nightly channel is used due to the contents of `rust-toolchain.toml`, but that's not needed for the release workflow.