### PR TITLE
ci: Minor cleanups in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,18 @@ jobs:
             ~/.cargo/.crates.toml
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install latest nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           targets: thumbv7m-none-eabi
           components: rustfmt, clippy
-      - run: cargo install cargo-readme
+
       - run: cargo fmt --check
       - run: cargo test
+      - run: cargo clippy --all-features
+      - run: cargo doc --all-features
 
       # Ensure that the library doesn't depend on std/alloc. A binary
       # that depends on the library is used for this (instead of
@@ -52,7 +55,6 @@ jobs:
         run: cargo build --target thumbv7m-none-eabi --no-default-features
         working-directory: ci/ensure_no_std
 
-      - run: cargo clippy --all-features
-      - run: cargo doc --all-features
-      - name: Ensure README.md is updated
+      - run: cargo install cargo-readme
+      - name: Ensure README.md is up-to-date
         run: '[ "$(< README.md)" = "$(cargo readme)" ]'


### PR DESCRIPTION
Add some whitespace for readability, and move the installation of cargo-readme down to where it's used.