### PR TITLE
Update to 2021 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   <https://github.com/lights0123/printf-compat/pull/25>
 * Output `(null)` when a null pointer is formatted with `%s`.
   <https://github.com/lights0123/printf-compat/pull/31>
+* Update to edition 2021.
+  <https://github.com/lights0123/printf-compat/pull/33>
 
 ## 0.2.0 (July 14, 2025)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "printf reimplemented in Rust"
 version = "0.2.0"
 repository = "https://github.com/lights0123/printf-compat"
 authors = ["lights0123 <developer@lights0123.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 


### PR DESCRIPTION
The immediate motivation for this is to use C string literals in the tests.