### PR TITLE
tests: Switch argument order of variable width

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -79,7 +79,7 @@ fn test_str() {
 #[test]
 fn test_int() {
     unsafe {
-        assert_eq_fmt!(c"% 0*i", 23125, 17);
+        assert_eq_fmt!(c"% 0*i", 17, 23125);
         assert_eq_fmt!(c"% 010i", 23125);
         assert_eq_fmt!(c"% 10i", 23125);
         assert_eq_fmt!(c"% 5i", 23125);


### PR DESCRIPTION
The width is specified before the value. Switch the argument order so that the resulting output's width is a more reasonable 17 instead of 23125. This is in preparation for modifying the test asserts to include the expected output.