### PR TITLE
tests: Update all tests to include the expected output

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -40,12 +40,6 @@ macro_rules! c_fmt {
 }
 
 macro_rules! assert_eq_fmt {
-    ($format:literal $(, $p:expr)*) => {
-        assert_eq!(
-            c_fmt!($format $(, $p)*),
-            *rust_fmt($format.as_ptr().cast(), $($p),*)
-        );
-    };
     ($format:literal $(, $p:expr)* => $expected:literal) => {
         let (bytes_written, s) = c_fmt!($format $(, $p)*);
         assert_eq!(s, $expected);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -46,6 +46,12 @@ macro_rules! assert_eq_fmt {
             *rust_fmt($format.as_ptr().cast(), $($p),*)
         );
     };
+    ($format:literal $(, $p:expr)* => $expected:literal) => {
+        let (bytes_written, s) = c_fmt!($format $(, $p)*);
+        assert_eq!(s, $expected);
+        assert_eq!((bytes_written, s), *rust_fmt($format.as_ptr().cast(), $($p),*));
+        assert_eq!(usize::try_from(bytes_written).unwrap(), $expected.len());
+    };
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -57,146 +57,146 @@ macro_rules! assert_eq_fmt {
 #[test]
 fn test_plain() {
     unsafe {
-        assert_eq_fmt!(c"abc");
-        assert_eq_fmt!(c"");
-        assert_eq_fmt!(c"%%");
-        assert_eq_fmt!(c"%% def");
-        assert_eq_fmt!(c"abc %%");
-        assert_eq_fmt!(c"abc %% def");
-        assert_eq_fmt!(c"abc %%%% def");
-        assert_eq_fmt!(c"%%%%%%");
+        assert_eq_fmt!(c"abc" => "abc");
+        assert_eq_fmt!(c"" => "");
+        assert_eq_fmt!(c"%%" => "%");
+        assert_eq_fmt!(c"%% def" => "% def");
+        assert_eq_fmt!(c"abc %%" => "abc %");
+        assert_eq_fmt!(c"abc %% def" => "abc % def");
+        assert_eq_fmt!(c"abc %%%% def" => "abc %% def");
+        assert_eq_fmt!(c"%%%%%%" => "%%%");
     }
 }
 
 #[test]
 fn test_str() {
     unsafe {
-        assert_eq_fmt!(c"hello %s", c"world");
-        assert_eq_fmt!(c"hello %%%s", c"world");
-        assert_eq_fmt!(c"%10s", c"world");
-        assert_eq_fmt!(c"%.4s", c"world");
-        assert_eq_fmt!(c"%10.4s", c"world");
-        assert_eq_fmt!(c"%-10.4s", c"world");
-        assert_eq_fmt!(c"%-10s", c"world");
-        assert_eq_fmt!(c"%s", null_mut::<c_char>());
+        assert_eq_fmt!(c"hello %s", c"world" => "hello world");
+        assert_eq_fmt!(c"hello %%%s", c"world" => "hello %world");
+        assert_eq_fmt!(c"%10s", c"world" => "     world");
+        assert_eq_fmt!(c"%.4s", c"world" => "worl");
+        assert_eq_fmt!(c"%10.4s", c"world" => "      worl");
+        assert_eq_fmt!(c"%-10.4s", c"world" => "worl      ");
+        assert_eq_fmt!(c"%-10s", c"world" => "world     ");
+        assert_eq_fmt!(c"%s", null_mut::<c_char>() => "(null)");
     }
 }
 
 #[test]
 fn test_int() {
     unsafe {
-        assert_eq_fmt!(c"% 0*i", 17, 23125);
-        assert_eq_fmt!(c"% 010i", 23125);
-        assert_eq_fmt!(c"% 10i", 23125);
-        assert_eq_fmt!(c"% 5i", 23125);
-        assert_eq_fmt!(c"% 4i", 23125);
-        assert_eq_fmt!(c"%- 010i", 23125);
-        assert_eq_fmt!(c"%- 10i", 23125);
-        assert_eq_fmt!(c"%- 5i", 23125);
-        assert_eq_fmt!(c"%- 4i", 23125);
-        assert_eq_fmt!(c"%+ 010i", 23125);
-        assert_eq_fmt!(c"%+ 10i", 23125);
-        assert_eq_fmt!(c"%+ 5i", 23125);
-        assert_eq_fmt!(c"%+ 4i", 23125);
-        assert_eq_fmt!(c"%-010i", 23125);
-        assert_eq_fmt!(c"%-10i", 23125);
-        assert_eq_fmt!(c"%-5i", 23125);
-        assert_eq_fmt!(c"%-4i", 23125);
+        assert_eq_fmt!(c"% 0*i", 17, 23125 => " 0000000000023125");
+        assert_eq_fmt!(c"% 010i", 23125 => " 000023125");
+        assert_eq_fmt!(c"% 10i", 23125 => "     23125");
+        assert_eq_fmt!(c"% 5i", 23125 => " 23125");
+        assert_eq_fmt!(c"% 4i", 23125 => " 23125");
+        assert_eq_fmt!(c"%- 010i", 23125 => " 23125    ");
+        assert_eq_fmt!(c"%- 10i", 23125 => " 23125    ");
+        assert_eq_fmt!(c"%- 5i", 23125 => " 23125");
+        assert_eq_fmt!(c"%- 4i", 23125 => " 23125");
+        assert_eq_fmt!(c"%+ 010i", 23125 => "+000023125");
+        assert_eq_fmt!(c"%+ 10i", 23125 => "    +23125");
+        assert_eq_fmt!(c"%+ 5i", 23125 => "+23125");
+        assert_eq_fmt!(c"%+ 4i", 23125 => "+23125");
+        assert_eq_fmt!(c"%-010i", 23125 => "23125     ");
+        assert_eq_fmt!(c"%-10i", 23125 => "23125     ");
+        assert_eq_fmt!(c"%-5i", 23125 => "23125");
+        assert_eq_fmt!(c"%-4i", 23125 => "23125");
     }
 }
 
 #[test]
 fn test_octal() {
     unsafe {
-        assert_eq_fmt!(c"% 010o", 23125);
-        assert_eq_fmt!(c"% 10o", 23125);
-        assert_eq_fmt!(c"% 5o", 23125);
-        assert_eq_fmt!(c"% 4o", 23125);
-        assert_eq_fmt!(c"%- 010o", 23125);
-        assert_eq_fmt!(c"%- 10o", 23125);
-        assert_eq_fmt!(c"%- 5o", 23125);
-        assert_eq_fmt!(c"%- 4o", 23125);
-        assert_eq_fmt!(c"%+ 010o", 23125);
-        assert_eq_fmt!(c"%+ 10o", 23125);
-        assert_eq_fmt!(c"%+ 5o", 23125);
-        assert_eq_fmt!(c"%+ 4o", 23125);
-        assert_eq_fmt!(c"%-010o", 23125);
-        assert_eq_fmt!(c"%-10o", 23125);
-        assert_eq_fmt!(c"%-5o", 23125);
-        assert_eq_fmt!(c"%-4o", 23125);
+        assert_eq_fmt!(c"% 010o", 23125 => "0000055125");
+        assert_eq_fmt!(c"% 10o", 23125 => "     55125");
+        assert_eq_fmt!(c"% 5o", 23125 => "55125");
+        assert_eq_fmt!(c"% 4o", 23125 => "55125");
+        assert_eq_fmt!(c"%- 010o", 23125 => "55125     ");
+        assert_eq_fmt!(c"%- 10o", 23125 => "55125     ");
+        assert_eq_fmt!(c"%- 5o", 23125 => "55125");
+        assert_eq_fmt!(c"%- 4o", 23125 => "55125");
+        assert_eq_fmt!(c"%+ 010o", 23125 => "0000055125");
+        assert_eq_fmt!(c"%+ 10o", 23125 => "     55125");
+        assert_eq_fmt!(c"%+ 5o", 23125 => "55125");
+        assert_eq_fmt!(c"%+ 4o", 23125 => "55125");
+        assert_eq_fmt!(c"%-010o", 23125 => "55125     ");
+        assert_eq_fmt!(c"%-10o", 23125 => "55125     ");
+        assert_eq_fmt!(c"%-5o", 23125 => "55125");
+        assert_eq_fmt!(c"%-4o", 23125 => "55125");
     }
 }
 
 #[test]
 fn test_hex() {
     unsafe {
-        assert_eq_fmt!(c"% 010x", 23125);
-        assert_eq_fmt!(c"% 10x", 23125);
-        assert_eq_fmt!(c"% 5x", 23125);
-        assert_eq_fmt!(c"% 4x", 23125);
-        assert_eq_fmt!(c"%- 010x", 23125);
-        assert_eq_fmt!(c"%- 10x", 23125);
-        assert_eq_fmt!(c"%- 5x", 23125);
-        assert_eq_fmt!(c"%- 4x", 23125);
-        assert_eq_fmt!(c"%+ 010x", 23125);
-        assert_eq_fmt!(c"%+ 10x", 23125);
-        assert_eq_fmt!(c"%+ 5x", 23125);
-        assert_eq_fmt!(c"%+ 4x", 23125);
-        assert_eq_fmt!(c"%-010x", 23125);
-        assert_eq_fmt!(c"%-10x", 23125);
-        assert_eq_fmt!(c"%-5x", 23125);
-        assert_eq_fmt!(c"%-4x", 23125);
+        assert_eq_fmt!(c"% 010x", 23125 => "0000005a55");
+        assert_eq_fmt!(c"% 10x", 23125 => "      5a55");
+        assert_eq_fmt!(c"% 5x", 23125 => " 5a55");
+        assert_eq_fmt!(c"% 4x", 23125 => "5a55");
+        assert_eq_fmt!(c"%- 010x", 23125 => "5a55      ");
+        assert_eq_fmt!(c"%- 10x", 23125 => "5a55      ");
+        assert_eq_fmt!(c"%- 5x", 23125 => "5a55 ");
+        assert_eq_fmt!(c"%- 4x", 23125 => "5a55");
+        assert_eq_fmt!(c"%+ 010x", 23125 => "0000005a55");
+        assert_eq_fmt!(c"%+ 10x", 23125 => "      5a55");
+        assert_eq_fmt!(c"%+ 5x", 23125 => " 5a55");
+        assert_eq_fmt!(c"%+ 4x", 23125 => "5a55");
+        assert_eq_fmt!(c"%-010x", 23125 => "5a55      ");
+        assert_eq_fmt!(c"%-10x", 23125 => "5a55      ");
+        assert_eq_fmt!(c"%-5x", 23125 => "5a55 ");
+        assert_eq_fmt!(c"%-4x", 23125 => "5a55");
 
-        assert_eq_fmt!(c"%# 010x", 23125);
-        assert_eq_fmt!(c"%# 10x", 23125);
-        assert_eq_fmt!(c"%# 5x", 23125);
-        assert_eq_fmt!(c"%# 4x", 23125);
-        assert_eq_fmt!(c"%#- 010x", 23125);
-        assert_eq_fmt!(c"%#- 10x", 23125);
-        assert_eq_fmt!(c"%#- 5x", 23125);
-        assert_eq_fmt!(c"%#- 4x", 23125);
-        assert_eq_fmt!(c"%#+ 010x", 23125);
-        assert_eq_fmt!(c"%#+ 10x", 23125);
-        assert_eq_fmt!(c"%#+ 5x", 23125);
-        assert_eq_fmt!(c"%#+ 4x", 23125);
-        assert_eq_fmt!(c"%#-010x", 23125);
-        assert_eq_fmt!(c"%#-10x", 23125);
-        assert_eq_fmt!(c"%#-5x", 23125);
-        assert_eq_fmt!(c"%#-4x", 23125);
+        assert_eq_fmt!(c"%# 010x", 23125 => "0x00005a55");
+        assert_eq_fmt!(c"%# 10x", 23125 => "    0x5a55");
+        assert_eq_fmt!(c"%# 5x", 23125 => "0x5a55");
+        assert_eq_fmt!(c"%# 4x", 23125 => "0x5a55");
+        assert_eq_fmt!(c"%#- 010x", 23125 => "0x5a55    ");
+        assert_eq_fmt!(c"%#- 10x", 23125 => "0x5a55    ");
+        assert_eq_fmt!(c"%#- 5x", 23125 => "0x5a55");
+        assert_eq_fmt!(c"%#- 4x", 23125 => "0x5a55");
+        assert_eq_fmt!(c"%#+ 010x", 23125 => "0x00005a55");
+        assert_eq_fmt!(c"%#+ 10x", 23125 => "    0x5a55");
+        assert_eq_fmt!(c"%#+ 5x", 23125 => "0x5a55");
+        assert_eq_fmt!(c"%#+ 4x", 23125 => "0x5a55");
+        assert_eq_fmt!(c"%#-010x", 23125 => "0x5a55    ");
+        assert_eq_fmt!(c"%#-10x", 23125 => "0x5a55    ");
+        assert_eq_fmt!(c"%#-5x", 23125 => "0x5a55");
+        assert_eq_fmt!(c"%#-4x", 23125 => "0x5a55");
 
-        assert_eq_fmt!(c"% 010X", 23125);
-        assert_eq_fmt!(c"% 10X", 23125);
-        assert_eq_fmt!(c"% 5X", 23125);
-        assert_eq_fmt!(c"% 4X", 23125);
-        assert_eq_fmt!(c"%- 010X", 23125);
-        assert_eq_fmt!(c"%- 10X", 23125);
-        assert_eq_fmt!(c"%- 5X", 23125);
-        assert_eq_fmt!(c"%- 4X", 23125);
-        assert_eq_fmt!(c"%+ 010X", 23125);
-        assert_eq_fmt!(c"%+ 10X", 23125);
-        assert_eq_fmt!(c"%+ 5X", 23125);
-        assert_eq_fmt!(c"%+ 4X", 23125);
-        assert_eq_fmt!(c"%-010X", 23125);
-        assert_eq_fmt!(c"%-10X", 23125);
-        assert_eq_fmt!(c"%-5X", 23125);
-        assert_eq_fmt!(c"%-4X", 23125);
+        assert_eq_fmt!(c"% 010X", 23125 => "0000005A55");
+        assert_eq_fmt!(c"% 10X", 23125 => "      5A55");
+        assert_eq_fmt!(c"% 5X", 23125 => " 5A55");
+        assert_eq_fmt!(c"% 4X", 23125 => "5A55");
+        assert_eq_fmt!(c"%- 010X", 23125 => "5A55      ");
+        assert_eq_fmt!(c"%- 10X", 23125 => "5A55      ");
+        assert_eq_fmt!(c"%- 5X", 23125 => "5A55 ");
+        assert_eq_fmt!(c"%- 4X", 23125 => "5A55");
+        assert_eq_fmt!(c"%+ 010X", 23125 => "0000005A55");
+        assert_eq_fmt!(c"%+ 10X", 23125 => "      5A55");
+        assert_eq_fmt!(c"%+ 5X", 23125 => " 5A55");
+        assert_eq_fmt!(c"%+ 4X", 23125 => "5A55");
+        assert_eq_fmt!(c"%-010X", 23125 => "5A55      ");
+        assert_eq_fmt!(c"%-10X", 23125 => "5A55      ");
+        assert_eq_fmt!(c"%-5X", 23125 => "5A55 ");
+        assert_eq_fmt!(c"%-4X", 23125 => "5A55");
     }
 }
 
 #[test]
 fn test_float() {
     unsafe {
-        assert_eq_fmt!(c"%f", 1234f64);
-        assert_eq_fmt!(c"%.5f", 1234f64);
-        assert_eq_fmt!(c"%.*f", 1234f64, 3);
+        assert_eq_fmt!(c"%f", 1234f64 => "1234.000000");
+        assert_eq_fmt!(c"%.5f", 1234f64 => "1234.00000");
+        assert_eq_fmt!(c"%.*f", 1234f64, 3 => "1234.000");
     }
 }
 
 #[test]
 fn test_char() {
     unsafe {
-        assert_eq_fmt!(c"%c", b'a' as c_int);
-        assert_eq_fmt!(c"%10c", b'a' as c_int);
-        assert_eq_fmt!(c"%-10c", b'a' as c_int);
+        assert_eq_fmt!(c"%c", b'a' as c_int => "a");
+        assert_eq_fmt!(c"%10c", b'a' as c_int => "         a");
+        assert_eq_fmt!(c"%-10c", b'a' as c_int => "a         ");
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -39,6 +39,17 @@ macro_rules! c_fmt {
     }};
 }
 
+/// Assert that `rust_fmt` produces the same output as C's `asprintf`,
+/// and that both match the `expected` literal.
+///
+/// This takes a format literal, followed by optional printf arguments,
+/// followed by `=>` and then the `expected` output.
+///
+/// Example usage:
+///
+/// ```
+/// assert_eq_fmt!(c"%d %d", 1, 2 => "1 2");
+/// ```
 macro_rules! assert_eq_fmt {
     ($format:literal $(, $p:expr)* => $expected:literal) => {
         let (bytes_written, s) = c_fmt!($format $(, $p)*);


### PR DESCRIPTION
The `assert_eq_fmt` macro now expects ` => "expected"` at the end, where "expected" is whatever the print should produce. This makes it easier to see what each test is supposed to cover.
    
Note that this does make the tests somewhat platform dependent, as the expected string might differ depending on the target and toolchain. However, in practice these tests are always being run on `x86_64-unknown-linux-gnu` currently, and we can cfg the tests to cover other toolchains later.