### PR TITLE
Drop the c_variadic feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## Unreleased
+
+* Drop the `c_variadic` feature, as it has been stabilized on nightly.
+  <https://github.com/lights0123/printf-compat/pull/63>
+
 ## 0.4.0 (April 26, 2026)
 
 * Fix compilation errors on recent nightlies due to changes in the std
   [`VaList` implementation](https://github.com/rust-lang/rust/pull/155614).
+  <https://github.com/lights0123/printf-compat/pull/54>
 
 ## 0.3.1 (January 24, 2026)
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 `printf` reimplemented in Rust
 
-This is a complete reimplementation of `printf` in Rust, using the unstable
-(i.e. **requires a Nightly compiler**) `c_variadic` feature.
+This is a complete reimplementation of `printf` in Rust. It requires the
+`c_variadic` feature, which will be stable in Rust 1.99, but currently
+requires the nightly toolchain.
 
 - [Many C][sigrok-log] [libraries][libusb-log] provide a way to provide a
   custom log callback. With this crate, you can provide a pure Rust option,
@@ -58,13 +59,7 @@ documented][output::fmt_write#differences].
 
 ## Getting Started
 
-Start by adding the unstable feature:
-
-```rust
-#![feature(c_variadic)]
-```
-
-Now, add your function signature:
+Start by adding your function signature:
 
 ```rust
 use core::ffi::{c_char, c_int};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //! `printf` reimplemented in Rust
 //!
-//! This is a complete reimplementation of `printf` in Rust, using the unstable
-//! (i.e. **requires a Nightly compiler**) `c_variadic` feature.
+//! This is a complete reimplementation of `printf` in Rust. It requires the
+//! `c_variadic` feature, which will be stable in Rust 1.99, but currently
+//! requires the nightly toolchain.
 //!
 //! - [Many C][sigrok-log] [libraries][libusb-log] provide a way to provide a
 //!   custom log callback. With this crate, you can provide a pure Rust option,
@@ -53,16 +54,9 @@
 //!
 //! # Getting Started
 //!
-//! Start by adding the unstable feature:
+//! Start by adding your function signature:
 //!
 //! ```rust
-//! #![feature(c_variadic)]
-//! ```
-//!
-//! Now, add your function signature:
-//!
-//! ```rust
-//! # #![feature(c_variadic)]
 //! use core::ffi::{c_char, c_int};
 //!
 //! #[unsafe(no_mangle)]
@@ -85,7 +79,6 @@
 //! Now, add your logic:
 //!
 //! ```rust
-//! # #![feature(c_variadic)]
 //! # use core::ffi::{c_char, c_int};
 //! # #[unsafe(no_mangle)]
 //! # unsafe extern "C" fn c_library_print(str: *const c_char, args: ...) -> c_int {
@@ -111,7 +104,6 @@
 //! [`defmt`]: https://defmt.ferrous-systems.com/
 
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
-#![feature(c_variadic)]
 
 use core::{ffi::*, fmt};
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -321,8 +321,6 @@ pub unsafe fn display<'a>(format: *const c_char, va_list: VaList<'a>) -> VaListD
 /// uses [`format_args!`], such as [`println!`] or the `log` crate.
 ///
 /// ```rust
-/// #![feature(c_variadic)]
-///
 /// use core::ffi::{c_char, c_int};
 ///
 /// #[unsafe(no_mangle)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,3 @@
-#![feature(c_variadic)]
-
 use core::{ffi::*, ptr::null_mut};
 
 unsafe extern "C" {


### PR DESCRIPTION
This feature is now stabilized on the nightly channel. Left a reference to it in the documentation for now, with a note that the library should work on stable in Rust 1.99.